### PR TITLE
Update PDF/A conformance level labels

### DIFF
--- a/Autodetect/1414/ua1pdfa2u.sch
+++ b/Autodetect/1414/ua1pdfa2u.sch
@@ -9,9 +9,9 @@
 
     <sch:pattern name = "Checking the validationReport: document is not compliant">
         <sch:rule context="/report/jobs/job/validationReport">
-            <sch:assert test="((@isCompliant = 'false' and contains(@profileName,'PDF/A-2U')) or 
+            <sch:assert test="((@isCompliant = 'false' and contains(@profileName,'PDF/A-2u')) or
             (@isCompliant = 'true' and contains(@profileName,'PDF/UA-1')))">Failed check, 
-            Expected: PDF/A-2U, isCompliant=false or PDF/UA-1, isCompliant=true</sch:assert>
+            Expected: PDF/A-2u, isCompliant=false or PDF/UA-1, isCompliant=true</sch:assert>
         </sch:rule>
     </sch:pattern>
 

--- a/CLI/Issues/1003/1003.bats
+++ b/CLI/Issues/1003/1003.bats
@@ -14,7 +14,7 @@ setup() {
   assert_output --partial '<?xml version="1.0" encoding="utf-8"?>'
   assert_output --partial '<report>'
   assert_output --partial '</report>'
-  assert_output --partial '<validationReport jobEndStatus="normal" profileName="PDF/A-2B validation profile" statement="PDF file is compliant with Validation Profile requirements." isCompliant="true">'
+  assert_output --partial '<validationReport jobEndStatus="normal" profileName="PDF/A-2b validation profile" statement="PDF file is compliant with Validation Profile requirements." isCompliant="true">'
 }
 
 # https://github.com/veraPDF/veraPDF-library/pull/1003
@@ -26,7 +26,7 @@ setup() {
   assert_output --partial '<?xml version="1.0" encoding="utf-8"?>'
   assert_output --partial '<report>'
   assert_output --partial '</report>'
-  assert_output --partial '<validationReport jobEndStatus="normal" profileName="PDF/A-2B validation profile" statement="PDF file is compliant with Validation Profile requirements." isCompliant="true">'
+  assert_output --partial '<validationReport jobEndStatus="normal" profileName="PDF/A-2b validation profile" statement="PDF file is compliant with Validation Profile requirements." isCompliant="true">'
 }
 
 # https://github.com/veraPDF/veraPDF-library/pull/1003

--- a/CLI/Issues/1136/1136.bats
+++ b/CLI/Issues/1136/1136.bats
@@ -10,7 +10,7 @@ setup() {
     run verapdf/verapdf --format html $BATS_TEST_DIRNAME/submission2-bad_symbols_in_font.pdf
 
     output=$(echo $output)
-    assert_output --partial '<td>PDF/A-1B validation profile</td> </tr> <tr> <td width="200" class="invalid"> Compliance: </td> <td class="invalid"> Failed </td>'
+    assert_output --partial '<td>PDF/A-1b validation profile</td> </tr> <tr> <td width="200" class="invalid"> Compliance: </td> <td class="invalid"> Failed </td>'
     assert_output --partial 'Specification: ISO 19005-1:2005, Clause: 6.3.4, Test number: 1'
     assert_output --partial 'font[0](TimesNewRoPSMT)'
 }

--- a/CLI/Issues/449/449.bats
+++ b/CLI/Issues/449/449.bats
@@ -19,5 +19,5 @@ setup() {
     [ "$status" -eq 0 ]
 
     assert_output --partial "--sdggdf doesn't exist"
-    assert_output --partial 'validationReport jobEndStatus="normal" profileName="PDF/A-1A validation profile" statement="PDF file is compliant with Validation Profile requirements." isCompliant="true"'
+    assert_output --partial 'validationReport jobEndStatus="normal" profileName="PDF/A-1a validation profile" statement="PDF file is compliant with Validation Profile requirements." isCompliant="true"'
 }

--- a/CLI/Options/defaultflavour/defaultflavour.bats
+++ b/CLI/Options/defaultflavour/defaultflavour.bats
@@ -6,17 +6,17 @@ FILES_TO_CHECK=(
 
 #Creating an associative array
 typeset -Ag profiles
-profiles[1a]=PDF/A-1A
-profiles[1b]=PDF/A-1B
-profiles[2a]=PDF/A-2A
-profiles[2b]=PDF/A-2B
-profiles[2u]=PDF/A-2U
-profiles[3a]=PDF/A-3A
-profiles[3b]=PDF/A-3B
-profiles[3u]=PDF/A-3U
+profiles[1a]=PDF/A-1a
+profiles[1b]=PDF/A-1b
+profiles[2a]=PDF/A-2a
+profiles[2b]=PDF/A-2b
+profiles[2u]=PDF/A-2u
+profiles[3a]=PDF/A-3a
+profiles[3b]=PDF/A-3b
+profiles[3u]=PDF/A-3u
 profiles[4]=PDF/A-4
-profiles[4f]=PDF/A-4F
-profiles[4E]=PDF/A-4E
+profiles[4f]=PDF/A-4f
+profiles[4E]=PDF/A-4e
 profiles[ua1]=PDF/UA-1
 profiles[ua2]="PDF/UA-2 + Tagged PDF"
 
@@ -48,7 +48,7 @@ setup() {
 flavour_by_default_check() {
     echo "Running: $1" >&3
     run verapdf/verapdf $FILE_PATH/$1
-    assert_output --partial 'profileName="PDF/A-1B validation profile"'
+    assert_output --partial 'profileName="PDF/A-1b validation profile"'
     assert [ "$status" == 1 ]
 }
 

--- a/CLI/Options/defaultflavour/defaultflavour.bats
+++ b/CLI/Options/defaultflavour/defaultflavour.bats
@@ -16,7 +16,7 @@ profiles[3b]=PDF/A-3b
 profiles[3u]=PDF/A-3u
 profiles[4]=PDF/A-4
 profiles[4f]=PDF/A-4f
-profiles[4E]=PDF/A-4e
+profiles[4e]=PDF/A-4e
 profiles[ua1]=PDF/UA-1
 profiles[ua2]="PDF/UA-2 + Tagged PDF"
 

--- a/CLI/Options/flavour/flavour.bats
+++ b/CLI/Options/flavour/flavour.bats
@@ -16,7 +16,7 @@ profiles[3b]=PDF/A-3b
 profiles[3u]=PDF/A-3u
 profiles[4]=PDF/A-4
 profiles[4f]=PDF/A-4f
-profiles[4E]=PDF/A-4e
+profiles[4e]=PDF/A-4e
 profiles[ua1]=PDF/UA-1
 profiles[ua2]="PDF/UA-2 + Tagged PDF"
 

--- a/CLI/Options/flavour/flavour.bats
+++ b/CLI/Options/flavour/flavour.bats
@@ -6,17 +6,17 @@ FILES_TO_CHECK=(
 
 #Creating an associative array
 typeset -Ag profiles
-profiles[1a]=PDF/A-1A
-profiles[1b]=PDF/A-1B
-profiles[2a]=PDF/A-2A
-profiles[2b]=PDF/A-2B
-profiles[2u]=PDF/A-2U
-profiles[3a]=PDF/A-3A
-profiles[3b]=PDF/A-3B
-profiles[3u]=PDF/A-3U
+profiles[1a]=PDF/A-1a
+profiles[1b]=PDF/A-1b
+profiles[2a]=PDF/A-2a
+profiles[2b]=PDF/A-2b
+profiles[2u]=PDF/A-2u
+profiles[3a]=PDF/A-3a
+profiles[3b]=PDF/A-3b
+profiles[3u]=PDF/A-3u
 profiles[4]=PDF/A-4
-profiles[4f]=PDF/A-4F
-profiles[4E]=PDF/A-4E
+profiles[4f]=PDF/A-4f
+profiles[4E]=PDF/A-4e
 profiles[ua1]=PDF/UA-1
 profiles[ua2]="PDF/UA-2 + Tagged PDF"
 
@@ -46,7 +46,7 @@ setup() {
 default_flavour_check() {
     echo "Running: $1" >&3
     run verapdf/verapdf $FILE_PATH/$1
-    assert_output --partial 'profileName="PDF/A-1B validation profile"'
+    assert_output --partial 'profileName="PDF/A-1b validation profile"'
     assert [ "$status" == 1 ]
 }
 

--- a/CLI/Options/format/format.bats
+++ b/CLI/Options/format/format.bats
@@ -96,7 +96,7 @@ format_text() {
 format_html() {
     echo "Running: $1" >&3
     run verapdf/verapdf $FILE_PATH/$1 --format html
-    assert_output --partial '<td>PDF/A-2B validation profile</td>'
+    assert_output --partial '<td>PDF/A-2b validation profile</td>'
     [ "$status" -eq 0 ]
 }
 
@@ -104,7 +104,7 @@ format_json() {
     echo "Running: $1" >&3
     run verapdf/verapdf $FILE_PATH/$1 --format json
     assert_output --partial '"jobEndStatus" : "normal",
-  "profileName" : "PDF/A-2B validation profile",
+  "profileName" : "PDF/A-2b validation profile",
   "statement" : "PDF file is compliant with Validation Profile requirements.",
   "compliant" : true'
 

--- a/CLI/Options/list/list.bats
+++ b/CLI/Options/list/list.bats
@@ -13,17 +13,17 @@ setup() {
 
     [ "$status" -eq 0 ]
     assert_output --partial "veraPDF supported PDF/A and PDF/UA profiles:"
-    assert_output --partial "1a - PDF/A-1A validation profile"
-    assert_output --partial "1b - PDF/A-1B validation profile"
-    assert_output --partial "2a - PDF/A-2A validation profile"
-    assert_output --partial "2b - PDF/A-2B validation profile"
-    assert_output --partial "2u - PDF/A-2U validation profile"
-    assert_output --partial "3a - PDF/A-3A validation profile"
-    assert_output --partial "3b - PDF/A-3B validation profile"
-    assert_output --partial "3u - PDF/A-3U validation profile"
+    assert_output --partial "1a - PDF/A-1a validation profile"
+    assert_output --partial "1b - PDF/A-1b validation profile"
+    assert_output --partial "2a - PDF/A-2a validation profile"
+    assert_output --partial "2b - PDF/A-2b validation profile"
+    assert_output --partial "2u - PDF/A-2u validation profile"
+    assert_output --partial "3a - PDF/A-3a validation profile"
+    assert_output --partial "3b - PDF/A-3b validation profile"
+    assert_output --partial "3u - PDF/A-3u validation profile"
     assert_output --partial "4 - PDF/A-4 validation profile"
-    assert_output --partial "4f - PDF/A-4F validation profile"
-    assert_output --partial "4e - PDF/A-4E validation profile"
+    assert_output --partial "4f - PDF/A-4f validation profile"
+    assert_output --partial "4e - PDF/A-4e validation profile"
     assert_output --partial "ua1 - PDF/UA-1 validation profile"
 
 }

--- a/CLI/Options/maxfailures/maxNumberOfDisplayedFailedChecks.bats
+++ b/CLI/Options/maxfailures/maxNumberOfDisplayedFailedChecks.bats
@@ -54,7 +54,7 @@ maxfailuresdisplayed_ignored_maxfailures_1() {
     echo "Running: $1" >&3
     run $BATS_TEST_TMPDIR/verapdf $BATS_TEST_TMPDIR/$1 --format html --maxfailures 1 --maxfailuresdisplayed 2
 
-    assert_output --partial '<td>PDF/A-3A validation profile</td>'
+    assert_output --partial '<td>PDF/A-3a validation profile</td>'
     assert_output --partial '1 occurrences'
     refute_output --partial "2 occurrences"
     [ "$status" -eq 1 ]
@@ -71,7 +71,7 @@ maxfailuresdisplayed_ignored_maxfailures_2() {
     run $BATS_TEST_TMPDIR/verapdf $BATS_TEST_TMPDIR/$1 --format html --maxfailures 2 --maxfailuresdisplayed 1
 
     [ "$status" -eq 1 ]
-    assert_output --partial '<td>PDF/A-3A validation profile</td>'
+    assert_output --partial '<td>PDF/A-3a validation profile</td>'
     assert_output --partial "2 occurrences"
 
     # Checking maxfailuresdisplayed ...

--- a/GUI/validation/vera_pdf_gui_on_startup.robot
+++ b/GUI/validation/vera_pdf_gui_on_startup.robot
@@ -84,17 +84,17 @@ Check PDF Flavour combox values on startup
     ${expectedList}=    createList
     ...    Custom profile
     ...    Auto-detect
-    ...    PDF/A-1A
-    ...    PDF/A-1B
-    ...    PDF/A-2A
-    ...    PDF/A-2B
-    ...    PDF/A-2U
-    ...    PDF/A-3A
-    ...    PDF/A-3B
-    ...    PDF/A-3U
+    ...    PDF/A-1a
+    ...    PDF/A-1b
+    ...    PDF/A-2a
+    ...    PDF/A-2b
+    ...    PDF/A-2u
+    ...    PDF/A-3a
+    ...    PDF/A-3b
+    ...    PDF/A-3u
     ...    PDF/A-4
-    ...    PDF/A-4E
-    ...    PDF/A-4F
+    ...    PDF/A-4e
+    ...    PDF/A-4f
     ...    PDF/UA-1
     ...    PDF/UA-2
     ...    WTPDF 1.0 Accessibility


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized PDF/A profile naming to use lowercase suffixes (e.g., PDF/A-1a, PDF/A-2b, PDF/A-3u) across validation reports.
  * Corrected displayed profile identifiers in the GUI flavour selection and command-line output (HTML/JSON/text) so profile names match the new casing consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->